### PR TITLE
Remove event emitter for connection errors and only use callbacks

### DIFF
--- a/lib/yapople.js
+++ b/lib/yapople.js
@@ -1,7 +1,6 @@
 'use strict';
 var net = require('net')
     , util = require('util')
-    , EventEmitter = require('events').EventEmitter
     , tls = require('tls')
 ;
 
@@ -40,8 +39,6 @@ var state = {
  * @constructor
  */
 var Client = function(options) {
-    EventEmitter.call(this);
-
     this.debug = false;
 
     /**
@@ -87,8 +84,6 @@ var Client = function(options) {
     this._command = { cmd: state.NOOP };
     // this.connect()
 };
-
-util.inherits(Client, EventEmitter);
 
 /**
  * Data event handler


### PR DESCRIPTION
Do we have a use case where we want to 1)Call the callback with an error and also 2)Emit the error?
If no we can safely remove EventEmitter.

Currently for promise based (or even callback based) projects, if they are unable to reach the client it throws an unhandled error crashing the project.

If we do need it I'll do another PR to add Event Emitter functions to client's TS definition so that the clients can add event handler with `client.on('error', cb)` which currently throws type error.