### PR TITLE
Sometimes doesn't parsing emails

### DIFF
--- a/__mocks__/tls.js
+++ b/__mocks__/tls.js
@@ -45,8 +45,7 @@ CjxIVE1MPjxCT0RZPjxkaXY+MTIzPC9kaXY+PGRpdj4xMjM8L2Rpdj48ZGl2IGRhdGEtc2lnbmF0
 dXJlLXdpZGdldD0iY29udGFpbmVyIj48ZGl2IGRhdGEtc2lnbmF0dXJlLXdpZGdldD0iY29udGVu
 dCI+PGRpdj4tLTxicj5ZYXBvcGxlIFlhcG9wbGU8L2Rpdj48L2Rpdj48L2Rpdj48L0JPRFk+PC9I
 VE1MPgo=
-----ALT--e2F8f5F19Ae0d3Ad5402B90c94Da42261610599299--
-.` + '\r\n';
+----ALT--e2F8f5F19Ae0d3Ad5402B90c94Da42261610599299--`+ '\r\n.\r\n';
 
 let messages = Array.from(new Array(4)).fill(msg);
 

--- a/lib/yapople.js
+++ b/lib/yapople.js
@@ -158,7 +158,7 @@ function onData(data) {
     if (typeof this.flow !== 'undefined') { // for first and all next data chunks
         this.flow = Buffer.concat([this.flow, data]); // append chunk to buffer
 
-        if (this._command.cmd === state.RETR && sData.slice(-5) !== '\r\n.\r\n') return;
+        if (this._command.cmd === state.RETR && this.flow.slice(-5).toString() !== '\r\n.\r\n') return;
         if (
             this.flow.slice(this.flow.length - 3).toString() === '.\r\n' ||
             sData.substr(-3) === '.\r\n'

--- a/lib/yapople.js
+++ b/lib/yapople.js
@@ -158,10 +158,8 @@ function onData(data) {
     if (typeof this.flow !== 'undefined') { // for first and all next data chunks
         this.flow = Buffer.concat([this.flow, data]); // append chunk to buffer
 
-        if (this._command.cmd === state.RETR && this.flow.slice(-5).toString() !== '\r\n.\r\n') return;
         if (
-            this.flow.slice(this.flow.length - 3).toString() === '.\r\n' ||
-            sData.substr(-3) === '.\r\n'
+            this.flow.slice(this.flow.length - 5).toString() === '\r\n.\r\n' || sData.substr(-5) === '\r\n.\r\n'
         ) {
             this.flow = this.flow.slice(0, this.flow.length - 5);
             if (this.mailparser) {

--- a/lib/yapople.js
+++ b/lib/yapople.js
@@ -158,6 +158,7 @@ function onData(data) {
     if (typeof this.flow !== 'undefined') { // for first and all next data chunks
         this.flow = Buffer.concat([this.flow, data]); // append chunk to buffer
 
+        if (this._command.cmd === state.RETR && sData.slice(-5) !== '\r\n.\r\n') return;
         if (
             this.flow.slice(this.flow.length - 3).toString() === '.\r\n' ||
             sData.substr(-3) === '.\r\n'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "yapople",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "author": "Andrew D.Laptev <a.d.laptev@gmail.com>",
   "description": "Yet another POP3 library",
   "main": "lib/yapople.js",


### PR DESCRIPTION
I found a problem where emails sometimes weren't parsed.

Some data events ends with .\r\n, But they doesn't finished parse whole email. 
I found some rfc documents and multiline commands should finish \r\n.\r\n. 

>    Responses to certain commands are multi-line.  In these cases, which
   are clearly indicated below, after sending the first line of the
   response and a CRLF, any additional lines are sent, each terminated
   by a CRLF pair.  When all lines of the response have been sent, a
   final line is sent, consisting of a termination octet (decimal code
   046, ".") and a CRLF pair.  If any line of the multi-line response
   begins with the termination octet, the line is "byte-stuffed" by
   pre-pending the termination octet to that line of the response.
   Hence a multi-line response is terminated with the five octets
   "CRLF.CRLF".  When examining a multi-line response, the client checks
   to see if the line begins with the termination octet.  If so and if
   octets other than CRLF follow, the first octet of the line (the
   termination octet) is stripped away.  If so and if CRLF immediately
   follows the termination character, then the response from the POP
   server is ended and the line containing ".CRLF" is not considered
   part of the multi-line response.

[https://www.ietf.org/rfc/rfc1939.txt](Rfc for POP3)

Please review my code, and if there are no problems, please merge.
Opinions are always appreciated, thank you for your hard work. 